### PR TITLE
Correctly deconstruct paths starting with file:/

### DIFF
--- a/plugins/eu.netide.configuration.utils/src/eu/netide/configuration/utils/NetIDEUtil.xtend
+++ b/plugins/eu.netide.configuration.utils/src/eu/netide/configuration/utils/NetIDEUtil.xtend
@@ -13,14 +13,18 @@ class NetIDEUtil {
 	
 	
 	static def absolutePath(String e) {
-		if (e != null && e.startsWith("platform:/resource"))
+		if (e != null && e.startsWith("platform:/resource")) {
 					if (Platform.getOS == Platform.OS_WIN32)
 						ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(e).removeFirstSegments(1)).rawLocation
 					else if (Platform.getOS == Platform.OS_LINUX || Platform.getOS == Platform.OS_MACOSX)
 						ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(e).removeFirstSegments(2)).rawLocation
-						 
-				else
-					new Path(e)
-		
+
+        } else {
+        	var p = new Path(e)
+            if (e.startsWith("file:/"))
+            	new Path("/" + p.removeFirstSegments(1))
+            else
+                p
+        }
 	}
 }


### PR DESCRIPTION
Before, we had
    file:/foo/bar -> null
now, we have
    file:/foo/bar -> /foo/bar

This allows using external files for example as the source code for a
network application without importing them into the workspace.

Signed-off-by: Gregor Best gbe@mail.upb.de
